### PR TITLE
Add Docker build step to CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,11 @@ jobs:
     - run: npm run build --if-present
       env:
         CI: true
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Build :latest
+        run: docker build .


### PR DESCRIPTION
Now that we're moving towards a `docker-compose` based build we may as well smoke test the `Dockerfile` on each push as well.