### PR TITLE
Disables automerge as workflows that merge into master don't trigger …

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -25,7 +25,7 @@ jobs:
         uses: "pascalgn/automerge-action@135f0bdb927d9807b5446f7ca9ecc2c51de03c4a"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_LABELS: "merge-when-passing, !wip,!work in progress"
+          MERGE_LABELS: "!wip,!work in progress"
           UPDATE_LABELS: "auto-rebase"
           UPDATE_METHOD: "rebase"
           MERGE_METHOD: "squash"


### PR DESCRIPTION
…the other flows for build/test/release which we need even more

Sorry for all the churn everyone! I love the automerge actions but they contraindicate auto-build and auto-deploy actinos on `master` which IMO we need even more.  You'll have to click to merge your own PRs into master now ;)