### PR TITLE
Basic connection handler for Mongo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}/src/app.js"
+    },
+    {
+			"type": "node",
+			"request": "launch",
+			"protocol": "inspector",
+			"name": "ES6 Debugger",
+			"program": "${workspaceFolder}/src/app.js",
+			"runtimeExecutable": "${workspaceRoot}/node_modules/.bin/babel-node",
+			"runtimeArgs": ["--presets",  "es2015"]
+		}
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ We have a github action defined in `.github/workflows/ci.yml` that will run a ba
 
 ## Running in Docker:
 
-__NOTE:__ We have a circular dependency issue since we need to run the mongo init script (`mongo-db-setup.sh`) before the pulse webservice can successfully start, but mongo has to be up to run the script. Currently this just means you have to `docker-compose up` twice: Once to get mongo up, and another after you've run the mongo DB setup script. What we should
-do soon is make the webservice more resilient to mongo failures and just have it continously retry to connect (with exponential backoff).
+__NOTE:__ The Pulse web service will fail to connect to Mongo until you run the `mongo-db-setup.sh` script. Once you do, the service will automatically connect to mongo.
 
 - Build the covital image: `docker build -t covital/ingress .`
 - Compose up the platform: `docker-compose -f devops/docker/compose/docker-compose.yml up -d --no-recreate`

--- a/src/app.js
+++ b/src/app.js
@@ -22,7 +22,6 @@ app.set('port', port);
     console.info('[init] Successfuly connected to mongodb');
   } catch (err) {
     console.info('[init] Mongodb connect error:\n', err);
-    process.exit(2);
   }
 
   // migrate.load(

--- a/src/config/db.js
+++ b/src/config/db.js
@@ -28,7 +28,53 @@ const dbPort = process.env.DBPORT || 27017;
 const dbName = process.env.DBNAME;
 const dbURL = `mongodb://${dbUser}:${dbPassword}@${dbAddress}:${dbPort}/${dbName}`;
 
-export function mongooseConnect() {
+const INITIAL_RETRY_INTERVAL_MS = 2000;
+const MAX_RETRY_INTERVAL_MS = 30000;
+
+class ConnectionRetryHandler {
+
+  constructor(initialRetryInterval, maxRetryInterval) {
+    this._inReconnectWait = false;
+    this._initialRetryInterval = initialRetryInterval;
+    this._maxRetryInterval = maxRetryInterval;
+    
+    mongoose.connection.on('disconnected', () => {
+      this.waitForReconnect();
+    });
+  }
+
+  async tryInitialConnect() {
+    await this.waitForReconnect();
+  }
+
+  async waitForReconnect(currentRetryInterval) {
+    // Don't try while waiting for a reconnect
+    if(this._inReconnectWait) return;
+
+    console.info('Connection to Mongo is gone. Trying to reconnect...');
+
+    this._inReconnectWait = true;
+
+    let thisInterval = currentRetryInterval ? currentRetryInterval : this._initialRetryInterval;
+    let nextInterval = Math.min(thisInterval * 2, this._maxRetryInterval);
+
+    try {
+      await mongoose.connect(dbURL, options);
+      console.log('Successfully reconnected to Mongo!');
+      this._inReconnectWait = false;
+    } catch(err) {
+      console.error(`Still unable to connect to mongo. Trying again in ${nextInterval / 1000} seconds`)
+      setTimeout(() => {
+        this._inReconnectWait = false;
+        this.waitForReconnect(nextInterval);
+      }, nextInterval);
+    }
+  }
+}
+
+const connHandler = new ConnectionRetryHandler(INITIAL_RETRY_INTERVAL_MS, MAX_RETRY_INTERVAL_MS);
+
+export async function mongooseConnect() {
   mongoose.set('useNewUrlParser', true);
   mongoose.set('useFindAndModify', false);
   mongoose.set('useCreateIndex', true);
@@ -36,7 +82,7 @@ export function mongooseConnect() {
 
   console.info('Connecting to mongo: ' + dbURL);
 
-  return mongoose.connect(dbURL, options);
+  await connHandler.tryInitialConnect();
 }
 
 export function mongooseDisconnect() {


### PR DESCRIPTION
We did not have any resilience to Mongo connection failures which made the app very fragile (especially when spinning up a new instance of the web service and Mongo with docker compose). This connection handler gracefully reconnects on both initial connection errors and errors after initial connection