### PR TITLE
Add dart client codegen script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 
 # compiled assets
 dist/*
+clients/*
 
 # asdf local version selector for node, npm, etc
 .tool-versions

--- a/script/generate-dart.sh
+++ b/script/generate-dart.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -ex
+
+SCHEMA=reference/pulseox-data-collector.v1.json
+
+docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
+    -i /local/${SCHEMA} \
+    -g dart \
+    -o /local/clients/dart


### PR DESCRIPTION
We have a Flutter app in progress that might provide a good crossplatform mobile experience. This will allow our Flutter Dart devs to generate client libraries for themselves.

```console
~/P/pulse-ox (djp-add-dart-generator|clean) ./script/generate-dart.sh
+ SCHEMA=reference/pulseox-data-collector.v1.json
+ docker run --rm -v /Users/dpritchett/Projects/pulse-ox:/local openapitools/openapi-generator-cli generate -i /local/reference/pulseox-data-collector.v1.json -g dart -o /local/clients/dart
[main] INFO  o.o.codegen.DefaultGenerator - Generating with dryRun=false
[main] INFO  o.o.codegen.DefaultGenerator - OpenAPI Generator: dart (client)
[main] INFO  o.o.codegen.DefaultGenerator - Generator 'dart' is considered stable.
[main] INFO  o.o.codegen.AbstractGenerator - writing file /local/clients/dart//lib/api_client.dart
[main] INFO  o.o.codegen.AbstractGenerator - writing file /local/clients/dart/README.md
[main] INFO  o.o.codegen.AbstractGenerator - writing file /local/clients/dart/.travis.yml
[main] INFO  o.o.codegen.AbstractGenerator - writing file /local/clients/dart/.openapi-generator/VERSION
~/P/pulse-ox (djp-add-dart-generator|clean)
```

This autogenerates a README for any selected client language too:
![image](https://user-images.githubusercontent.com/147981/77768353-5e2cbf80-7010-11ea-9ac6-8d88fe8e9648.png)
