### PR TITLE
Redirects / root url to /api-docs

### DIFF
--- a/src/openapi-app.js
+++ b/src/openapi-app.js
@@ -16,6 +16,9 @@ app.use(express.json());
 api.init();
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+
+app.get('/', (req, res) => { res.redirect('/api-docs') });
 
 // use as express middleware
 app.use((req, res) => api.handleRequest(req, req, res));


### PR DESCRIPTION
The existing 404 on `/` was bumming me out!

```
~ curl -I http://localhost:9000
HTTP/1.1 302 Found
X-Powered-By: Express
Location: /api-docs
Vary: Accept
Content-Type: text/plain; charset=utf-8
Content-Length: 31
Date: Fri, 27 Mar 2020 20:40:03 GMT
Connection: keep-alive
```