### PR TITLE
Fix openapiv3 validation error and previously broken schema validatio…

### DIFF
--- a/reference/pulseox-data-collector.v1.json
+++ b/reference/pulseox-data-collector.v1.json
@@ -228,16 +228,7 @@
             "description": "OK"
           }
         },
-        "operationId": "get-session-diagnoses",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object"
-              }
-            }
-          }
-        }
+        "operationId": "get-session-diagnoses"
       }
     },
     "/session/diagnoses/{diagid}": {

--- a/src/openapi-app.js
+++ b/src/openapi-app.js
@@ -19,6 +19,7 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 app.get('/', (req, res) => { res.redirect('/api-docs') });
+app.get('/swagger.json', (req, res) => { res.send(swaggerDocument) });
 
 // use as express middleware
 app.use((req, res) => api.handleRequest(req, req, res));

--- a/test/api_schema.test.js
+++ b/test/api_schema.test.js
@@ -2,9 +2,11 @@ const { Enforcer } = require('openapi-enforcer');
 const schemaDoc = require('../src/api_schema');
 
 test('schema is valid OpenAPIV3', () =>{
-    Enforcer(schemaDoc, { fullResult: true} )
+    return Enforcer(schemaDoc, { fullResult: true} )
         .then( ({ error, warning }) => {
             expect(error).toBeUndefined();
             expect(warning).toBeUndefined();
-        })
+        }).catch((err) => {
+            expect(err).toBeUndefined();
+    });
 });


### PR DESCRIPTION
…n test

@palfaiate it looks like my schema validation test accidentally let something slip through. I've fixed the test and removed what appears to be superfluous schema bits that were causing us to fail validation:
![image](https://user-images.githubusercontent.com/147981/77861815-f9729000-71dc-11ea-9709-ba3d61ccbda1.png)

Please let me know if we need to find a way to put that bit back in while maintaining spec validation.