### PR TITLE
Fix for missing source parameter in GET /signed-upload

### DIFF
--- a/reference/pulseox-data-collector.v1.json
+++ b/reference/pulseox-data-collector.v1.json
@@ -49,6 +49,16 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "description": "The source of the data to upload",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [ "community", "clinical" ]
+            }
           }
         ],
         "responses": {

--- a/src/api.js
+++ b/src/api.js
@@ -93,6 +93,11 @@ const handlers = {
   getSignedUploadReq: (r, req, res) => {
     const fileName = req.query.filename;
     const fileType = req.query.filetype;
+    const source = req.query.source;
+
+    if (!source) {
+      return returns.failure(r, req, res)(new Error('You must specify a source'));
+    }
 
     if(!fileName || !fileType) {
       return returns.failure(r, req, res)(new Error('You must specify filename and filetype params'));
@@ -100,7 +105,7 @@ const handlers = {
 
     const surveyId = uuidv4();
 
-    s3Service.getSignedUploadReq(surveyId, fileName, fileType)
+    s3Service.getSignedUploadReq(surveyId, fileName, fileType, source)
       .then(
         returns.success(r, req, res),
         returns.failure(r, req, res)


### PR DESCRIPTION
Recently, the batched-signed-upload-req API was modified to use a source parameter which is expected to be an enum [ "community", "clinical" ]. The similar API, get-signed-upload-req, now fails because the source parameter is not being supplied to the S3 service where it is expected. 

This PR modifies the get-signed-upload-req method to accept a source parameter and properly pass it along to the S3 Service.